### PR TITLE
string changes related to openapi

### DIFF
--- a/src/tutorial/crud.md
+++ b/src/tutorial/crud.md
@@ -141,7 +141,7 @@ To `GET` an item by `id` add the code below `app.MapPost` route created earlier
 app.MapGet("/todos/{id}", async (TodoDb db, int id) => await db.Todos.FindAsync(id));
 
 ```
-To check this out you can either go to `https://localhost:5001/todos/1` or use the swagger UI.
+To check this out you can either go to `https://localhost:5001/todos/1` or use the Swagger UI.
  ![swagger-get-todos-item](https://user-images.githubusercontent.com/2546640/125182403-bd99e900-e1db-11eb-83bb-72eb89b4386f.gif)
 
 ## Update an item 

--- a/src/tutorial/first-steps.md
+++ b/src/tutorial/first-steps.md
@@ -118,9 +118,9 @@ app.UseSwaggerUI(c =>
 });
 ```
 The code snippet above does the following
-- `app.UseSwagger` enables middleware to serve generated Swagger as JSON endpoint. 
-- `app.UseSwaggerUI` enables middle to serve the UI elements.
-- `SwaggerEndpoint` specifies the swagger endpoint.
+- `app.UseSwagger` enables middleware to serve the generated OpenAPI description as JSON content. 
+- `app.UseSwaggerUI` enables middle to serve the Swagger UI elements.
+- `SwaggerEndpoint` specifies the OpenAPI description's endpoint.
 
 Go back to your browser where your app is and navigate to this URL `https://localhost:5001/swagger`
 

--- a/src/tutorial/first-steps.md
+++ b/src/tutorial/first-steps.md
@@ -83,7 +83,7 @@ You will see the JSON response
 
 ### Add Swagger UI to your application 
 
- **Install the Microsoft Open API and Swagger packages.** 
+ **Install the Microsoft OpenAPI and Swagger packages.** 
 
 **Using .NET CLI**
 
@@ -133,7 +133,7 @@ Now, Swagger UI is   setup you can visualize and interact with your API.
 ![swaggertodo](https://user-images.githubusercontent.com/2546640/125180523-0005fa80-e1c9-11eb-885c-46b7bbb9fef3.gif)
 
 ### Learn checklist two ✔️ 
-- Configured and implementing Swagger 
+- Configured and implementing OpenAPI and Swagger UI 
 - Introduced to middleware and dependency injection.
 
 


### PR DESCRIPTION
Made a few changes throughout the existing quick start and tutorials to make sure we're referring to OpenAPI and the former term, Swagger, as well as the tools and UI components in Swagger UI. These are changes someone in the OpenAPI leadership (like Darrel) would have suggested. I'll make sure to differentiate between these concepts in the tutorial I write so the terminology usage is consistent.