### PR TITLE
Wildcard character position change

### DIFF
--- a/src/hello-minimal/README.md
+++ b/src/hello-minimal/README.md
@@ -441,7 +441,7 @@ Microsoft.AspNetCore.Http.BadHttpRequestException: Failed to bind parameter "int
 ### Wildcards/Catch all routes
 
 ```csharp
-app.MapGet("/posts/{rest*}", (string rest) => $"Routing to {rest}");
+app.MapGet("/posts/{*rest}", (string rest) => $"Routing to {rest}");
 ```
 
 ### Route constraints


### PR DESCRIPTION
Wildcard character should be **before** the parameter, not after.

See: https://docs.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis?view=aspnetcore-6.0#wildcard-and-catch-all-routes